### PR TITLE
fix: add default content if no activities are found

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ Toolkit.run(
       // Join items to one string
       .join('\n')
 
+    if (content == '') {
+      content = '⁉️ No recent activity performed!'
+    }
+
     const box = new GistBox({ id: GIST_ID, token: GH_PAT })
     try {
       tools.log.debug(`Updating Gist ${GIST_ID}`)


### PR DESCRIPTION
If the user have not performed any activity for a while, the content that is generated for the gist will be empty.

This PR changes the behavior such that if there is no activity to be displayed, it will show a default empty content.

---

Sidenote, it looks like the underlying `gist-box` (https://github.com/JasonEtco/gist-box) package also suffers a problem where boxes with empty content will basically "clear" the gist file. This will cause a problem since on the next request, no files will be defined (specifically https://github.com/JasonEtco/gist-box/blob/57d4580043b4b1b144cad2979dd2961c67a90f89/src/index.ts#L63).

Should I also open a PR to handle it?